### PR TITLE
ipywidgets: update 7.6.3 to 7.6.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - nbformat >=4.2.0
     - widgetsnbextension >=3.5.0,<3.6.0
     - jupyterlab_widgets >=1.0.0
+    - ipython_genutils >=0.2.0,<0.3.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - nbformat >=4.2.0
     - widgetsnbextension >=3.5.0,<3.6.0
     - jupyterlab_widgets >=1.0.0
+    - ipython_genutils >=0.2.0,<0.3.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
     - ipython >=4.0.0
@@ -31,6 +33,10 @@ requirements:
 test:
   imports:
     - ipywidgets
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/ipython/ipywidgets

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "7.6.3" %}
-{% set sha256 = "9f1a43e620530f9e570e4a493677d25f08310118d315b00e25a18f12913c41f0" %}
+{% set version = "7.6.4" %}
+{% set sha256 = "028bf014a0b1d77cb676fe163115f145aacdde0bb9a51c4166940e5b62a7d1d0" %}
 
 package:
   name: ipywidgets
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - nbformat >=4.2.0
     - widgetsnbextension >=3.5.0,<3.6.0
     - jupyterlab_widgets >=1.0.0
-    - ipython_genutils >=0.2.0,<0.3.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ about:
   description: |
     ipywidgets are interactive HTML widgets for Jupyter notebooks and the IPython kernel.
   doc_url: https://ipywidgets.readthedocs.io/en/latest/
+  dev_url: https://github.com/ipython/ipywidgets
   doc_source_url: https://github.com/jupyter-widgets/ipywidgets/blob/master/docs/source/index.rst
 
 extra:


### PR DESCRIPTION
* [x] upstream repo https://github.com/jupyter-widgets/ipywidgets
* [x] run tests on dependent packages
  * build jupyter with new ipywidgets
* [x] go through [changelog](https://github.com/jupyter-widgets/ipywidgets/blob/master/docs/source/changelog.md)
  * changelog only calls out major version changes - [diff](https://github.com/jupyter-widgets/ipywidgets/compare/7.6.3...7.6.4) between 7.6.3..7.6.4
* [x] look for any open issues for new versions
  * too many open issues to look but none contain the text 7.6.4
* [x] dev_url, doc_url valid
* [x] setuptools/wheel/pip/pip check included
* [x] compare pinned versions from upstream github setup
```
setup.cfg
        'Programming Language :: Python',
        'Programming Language :: Python :: 2.7',
        'Programming Language :: Python :: 3',
        'Programming Language :: Python :: 3.3',
        'Programming Language :: Python :: 3.4',
        'Programming Language :: Python :: 3.5',
    'ipykernel>=4.5.1',
    'ipython_genutils~=0.2.0',
    'traitlets>=4.3.1',
    'nbformat>=4.2.0',
    'widgetsnbextension~=3.5.0'
    ':python_version<"3.3"' : ['ipython>=4.0.0,<6.0.0'],
    ':python_version>="3.3"': ['ipython>=4.0.0'],
    ':python_version>="3.6"': ['jupyterlab_widgets>=1.0.0'],

meta.yaml
    - ipython >=4.0.0
    - ipykernel >=4.5.1
    - traitlets >=4.3.1,<6.0.0
    - nbformat >=4.2.0
    - widgetsnbextension >=3.5.0,<3.6.0
    - jupyterlab_widgets >=1.0.0
```