### PR TITLE
Update ipywidgets to 7.6.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "7.6.3" %}
-{% set sha256 = "9f1a43e620530f9e570e4a493677d25f08310118d315b00e25a18f12913c41f0" %}
+{% set version = "7.6.5" %}
+{% set sha256 = "00974f7cb4d5f8d494c19810fedb9fa9b64bffd3cda7c2be23c133a1ad3c99c5" %}
 
 package:
   name: ipywidgets

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - python
     - pip
   run:
-    - python
+    - python >=3.6
     - ipython >=4.0.0
     - ipykernel >=4.5.1
     - traitlets >=4.3.1,<6.0.0
@@ -30,6 +30,11 @@ requirements:
 test:
   imports:
     - ipywidgets
+  requires:
+    - pip
+    - python <3.10
+  commands:
+    - pip check
 
 about:
   home: https://github.com/ipython/ipywidgets
@@ -41,6 +46,7 @@ about:
     ipywidgets are interactive HTML widgets for Jupyter notebooks and the IPython kernel.
   doc_url: https://ipywidgets.readthedocs.io/en/latest/
   doc_source_url: https://github.com/jupyter-widgets/ipywidgets/blob/master/docs/source/index.rst
+  dev_url: https://github.com/ipython/ipywidgets
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
1. check the upstream
https://github.com/jupyter-widgets/ipywidgets/tree/7.6.5

2. check the pinnings
https://github.com/jupyter-widgets/ipywidgets/blob/7.6.5/setup.py

3. check changelogs
https://github.com/jupyter-widgets/ipywidgets/blob/7.6.5/docs/source/changelog.md

There were no breaking changes mentioned in the changelog
The changes mentioned were bug fixes or feature additions:

installing `ipywidgets` `7.6.0` will now automatically enable `ipywidgets` support in `JupyterLab` `3.0—a` user has no extra `JupyterLab` installation step and no rebuild of `JupyterLab`

4. additional research
https://github.com/conda-forge/ipywidgets-feedstock/issues

There are no open issues currently mentioned in conda-forge

5. add the dev_url
https://github.com/ipython/ipywidgets

6. verify doc_url
7. added pip to the test section
9. verify the test section
10. additional tests

In order to test the `ipywidgets` package, the following command was used:
`conda build ipywidgets-feedstock --test`
The test result was as follows:
`All tests passed` 

In addition, in order to test `ipywidgests` the `qgrid` package was used. 
The pinnings for `ipywidgests` were modified in the `qgrid` `meta.yaml`
The following command was used to test the package
`conda build qgrid-feedstock --test`
The test results were the following
`All tests passed`
